### PR TITLE
feat: 대시보드 FCM 토픽 알림 지원

### DIFF
--- a/apps/detections/models.py
+++ b/apps/detections/models.py
@@ -17,9 +17,7 @@ class Detection(models.Model):
     ]
 
     # MSA: FK 대신 ID로 참조 (Vehicles Service)
-    vehicle_id = models.BigIntegerField(
-        null=True, blank=True, verbose_name="차량 ID"
-    )
+    vehicle_id = models.BigIntegerField(null=True, blank=True, verbose_name="차량 ID")
     detected_speed = models.FloatField(verbose_name="감지 속도")
     speed_limit = models.FloatField(default=60.0, verbose_name="제한 속도")
     location = models.CharField(

--- a/apps/detections/models.py
+++ b/apps/detections/models.py
@@ -18,7 +18,7 @@ class Detection(models.Model):
 
     # MSA: FK 대신 ID로 참조 (Vehicles Service)
     vehicle_id = models.BigIntegerField(
-        null=True, blank=True, db_index=True, verbose_name="차량 ID"
+        null=True, blank=True, verbose_name="차량 ID"
     )
     detected_speed = models.FloatField(verbose_name="감지 속도")
     speed_limit = models.FloatField(default=60.0, verbose_name="제한 속도")

--- a/apps/detections/views.py
+++ b/apps/detections/views.py
@@ -37,33 +37,22 @@ class DetectionViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=False, methods=["get"])
     def statistics(self, request):
         """위반 통계"""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
         queryset = Detection.objects.using("detections_db").all()
 
         # 기간 필터 (선택)
         period = request.query_params.get("period")
-        if period == "today":
-            from datetime import timedelta
-
-            from django.utils import timezone
-
+        period_map = {
+            "today": timedelta(days=1),
+            "week": timedelta(weeks=1),
+            "month": timedelta(days=30),
+        }
+        if period in period_map:
             queryset = queryset.filter(
-                detected_at__gte=timezone.now() - timedelta(days=1)
-            )
-        elif period == "week":
-            from datetime import timedelta
-
-            from django.utils import timezone
-
-            queryset = queryset.filter(
-                detected_at__gte=timezone.now() - timedelta(weeks=1)
-            )
-        elif period == "month":
-            from datetime import timedelta
-
-            from django.utils import timezone
-
-            queryset = queryset.filter(
-                detected_at__gte=timezone.now() - timedelta(days=30)
+                detected_at__gte=timezone.now() - period_map[period]
             )
 
         # 카메라 필터 (선택)

--- a/apps/notifications/models.py
+++ b/apps/notifications/models.py
@@ -16,7 +16,7 @@ class Notification(models.Model):
     ]
 
     # MSA: FK 대신 ID로 참조 (Detections Service)
-    detection_id = models.BigIntegerField(db_index=True, verbose_name="감지 내역 ID")
+    detection_id = models.BigIntegerField(verbose_name="감지 내역 ID")
     fcm_token = models.CharField(
         max_length=255, blank=True, null=True, verbose_name="FCM 토큰"
     )

--- a/apps/vehicles/models.py
+++ b/apps/vehicles/models.py
@@ -28,7 +28,6 @@ class Vehicle(models.Model):
         verbose_name = "차량"
         verbose_name_plural = "차량 목록"
         indexes = [
-            models.Index(fields=["plate_number"]),
             models.Index(fields=["fcm_token"]),
         ]
 

--- a/apps/vehicles/views.py
+++ b/apps/vehicles/views.py
@@ -68,7 +68,9 @@ class VehicleViewSet(viewsets.ModelViewSet):
             try:
                 FCM_MOCK = os.getenv("FCM_MOCK", "false").lower() == "true"
                 if FCM_MOCK:
-                    logger.info("[MOCK] Would subscribe token to dashboard_alerts topic")
+                    logger.info(
+                        "[MOCK] Would subscribe token to dashboard_alerts topic"
+                    )
                 else:
                     from core.firebase.fcm import get_fcm_client
 

--- a/apps/vehicles/views.py
+++ b/apps/vehicles/views.py
@@ -1,3 +1,6 @@
+import logging
+import os
+
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -8,6 +11,8 @@ from .serializers import (
     VehicleCreateSerializer,
     VehicleSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class VehicleViewSet(viewsets.ModelViewSet):
@@ -57,6 +62,21 @@ class VehicleViewSet(viewsets.ModelViewSet):
         vehicle, created = Vehicle.objects.using("vehicles_db").update_or_create(
             plate_number=plate_number, defaults={"fcm_token": fcm_token}
         )
+
+        # Dashboard 토큰은 FCM 토픽에 구독
+        if plate_number == "DASHBOARD":
+            try:
+                FCM_MOCK = os.getenv("FCM_MOCK", "false").lower() == "true"
+                if FCM_MOCK:
+                    logger.info("[MOCK] Would subscribe token to dashboard_alerts topic")
+                else:
+                    from core.firebase.fcm import get_fcm_client
+
+                    fcm_client = get_fcm_client()
+                    fcm_client.subscribe_to_topic([fcm_token], "dashboard_alerts")
+                    logger.info("Dashboard token subscribed to dashboard_alerts topic")
+            except Exception as e:
+                logger.warning(f"Failed to subscribe dashboard token to topic: {e}")
 
         return Response(
             VehicleSerializer(vehicle).data,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,7 +1,5 @@
 """Celery Configuration"""
 
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 from celery import Celery

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -67,5 +67,5 @@ DATABASE_ROUTERS = ["config.db_router.MSADatabaseRouter"]
 # ==================================================
 # CORS 설정
 # ==================================================
-CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
-CORS_ALLOW_CREDENTIALS = True
+_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "")
+CORS_ALLOWED_ORIGINS = [o for o in _cors_origins.split(",") if o]

--- a/core/firebase/fcm.py
+++ b/core/firebase/fcm.py
@@ -108,6 +108,36 @@ class FCMClient:
         )
         return result
 
+    def subscribe_to_topic(self, tokens: List[str], topic: str) -> Dict:
+        """토큰을 FCM 토픽에 구독"""
+        from firebase_admin import messaging
+
+        response = messaging.subscribe_to_topic(tokens, topic)
+        logger.info(
+            f"FCM topic subscribe '{topic}': {response.success_count} success, "
+            f"{response.failure_count} failed"
+        )
+        return {
+            "success_count": response.success_count,
+            "failure_count": response.failure_count,
+        }
+
+    def send_to_topic(
+        self, topic: str, title: str, body: str, data: Optional[Dict[str, str]] = None
+    ) -> str:
+        """토픽으로 알림 전송"""
+        from firebase_admin import messaging
+
+        message = messaging.Message(
+            notification=messaging.Notification(title=title, body=body),
+            data=data or {},
+            topic=topic,
+        )
+
+        response = messaging.send(message)
+        logger.info(f"FCM sent to topic '{topic}': {response}")
+        return response
+
 
 # 편의 함수
 _fcm_client = None
@@ -125,3 +155,15 @@ def send_push_notification(
 ) -> str:
     """푸시 알림 전송 (편의 함수)"""
     return get_fcm_client().send_to_token(token, title, body, data)
+
+
+def subscribe_tokens_to_topic(tokens: List[str], topic: str) -> Dict:
+    """토픽 구독 (편의 함수)"""
+    return get_fcm_client().subscribe_to_topic(tokens, topic)
+
+
+def send_topic_notification(
+    topic: str, title: str, body: str, data: Optional[Dict[str, str]] = None
+) -> str:
+    """토픽 알림 전송 (편의 함수)"""
+    return get_fcm_client().send_to_topic(topic, title, body, data)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,5 +1,6 @@
 # Celery Tasks Package
+from .dlq_tasks import process_dlq_message
 from .notification_tasks import send_notification
 from .ocr_tasks import process_ocr
 
-__all__ = ["process_ocr", "send_notification"]
+__all__ = ["process_ocr", "send_notification", "process_dlq_message"]

--- a/tasks/dlq_tasks.py
+++ b/tasks/dlq_tasks.py
@@ -34,6 +34,7 @@ def process_dlq_message(self, *args, **kwargs):
             Detection.objects.using("detections_db").filter(id=detection_id).update(
                 status="failed",
                 error_message=f"DLQ: {death_reason} from {original_queue}",
+                # QuerySet.update() bypasses auto_now, so set explicitly
                 updated_at=timezone.now(),
             )
             logger.info(f"Detection {detection_id} marked as failed via DLQ")

--- a/tasks/notification_tasks.py
+++ b/tasks/notification_tasks.py
@@ -23,7 +23,8 @@ FCM_MOCK = os.getenv("FCM_MOCK", "false").lower() == "true"
 def send_notification(self, detection_id: int):
     """
     FCM 푸시 알림 전송 Task
-    - Exponential Backoff 재시도
+    - 대시보드 토픽 브로드캐스트 (모든 감지에 대해)
+    - 매칭된 차량 개별 푸시 (차량 있는 경우)
     - MSA: 각 서비스별 DB에서 조회
     """
     from apps.detections.models import Detection
@@ -36,7 +37,55 @@ def send_notification(self, detection_id: int):
             id=detection_id, status="completed"
         )
 
-        # 2. Vehicle 조회 (vehicles_db) - MSA: 별도 DB
+        # 2. 알림 메시지 생성
+        title = f"⚠️ 과속 위반 감지: {detection.ocr_result}"
+        body = (
+            f"📍 위치: {detection.location}\n"
+            f"🚗 속도: {detection.detected_speed}km/h "
+            f"(제한: {detection.speed_limit}km/h)"
+        )
+        data = {
+            "detection_id": str(detection_id),
+            "plate_number": detection.ocr_result or "",
+            "speed": str(detection.detected_speed),
+            "speed_limit": str(detection.speed_limit),
+            "location": detection.location or "",
+            "detected_at": detection.detected_at.isoformat(),
+        }
+
+        # 3. 대시보드 토픽으로 항상 전송
+        topic_response = None
+        try:
+            if FCM_MOCK:
+                topic_response = f"mock-topic-{detection_id}"
+            else:
+                from core.firebase.fcm import send_topic_notification
+
+                topic_response = send_topic_notification(
+                    "dashboard_alerts", title, body, data
+                )
+            logger.info(
+                f"Dashboard topic notification sent for detection "
+                f"{detection_id}: {topic_response}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Dashboard topic notification failed for detection "
+                f"{detection_id}: {e}"
+            )
+
+        # 4. 토픽 알림 이력 저장 (notifications_db)
+        Notification.objects.using("notifications_db").create(
+            detection_id=detection_id,
+            fcm_token="topic:dashboard_alerts",
+            title=title,
+            body=body,
+            status="sent" if topic_response else "failed",
+            sent_at=timezone.now() if topic_response else None,
+            error_message=None if topic_response else "Topic send failed",
+        )
+
+        # 5. 매칭된 차량에 개별 푸시 (기존 동작)
         vehicle = None
         if detection.vehicle_id:
             try:
@@ -46,63 +95,60 @@ def send_notification(self, detection_id: int):
             except Vehicle.DoesNotExist:
                 logger.warning(f"Vehicle {detection.vehicle_id} not found")
 
-        if not vehicle or not vehicle.fcm_token:
-            logger.warning(f"No FCM token for detection {detection_id}")
-            return {"status": "skipped", "reason": "No FCM token"}
+        if vehicle and vehicle.fcm_token:
+            try:
+                if FCM_MOCK:
+                    vehicle_response = f"mock-message-id-{detection_id}"
+                else:
+                    from core.firebase.fcm import send_push_notification
 
-        # 3. FCM 메시지 생성
-        title = f"⚠️ 과속 위반 감지: {detection.ocr_result}"
-        body = (
-            f"📍 위치: {detection.location}\n"
-            f"🚗 속도: {detection.detected_speed}km/h "
-            f"(제한: {detection.speed_limit}km/h)"
-        )
+                    vehicle_response = send_push_notification(
+                        token=vehicle.fcm_token,
+                        title=title,
+                        body=body,
+                        data=data,
+                    )
 
-        if FCM_MOCK:
-            # Mock 모드
-            import random
-            import time
+                Notification.objects.using("notifications_db").create(
+                    detection_id=detection_id,
+                    fcm_token=vehicle.fcm_token,
+                    title=title,
+                    body=body,
+                    status="sent",
+                    sent_at=timezone.now(),
+                )
+                logger.info(
+                    f"Vehicle notification sent for detection "
+                    f"{detection_id}: {vehicle_response}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Vehicle notification failed for detection "
+                    f"{detection_id}: {e}"
+                )
+                Notification.objects.using("notifications_db").create(
+                    detection_id=detection_id,
+                    fcm_token=vehicle.fcm_token,
+                    title=title,
+                    body=body,
+                    status="failed",
+                    error_message=str(e),
+                )
 
-            time.sleep(random.uniform(0.05, 0.1))
-            response = f"mock-message-id-{detection_id}"
-        else:
-            # 실제 FCM 전송 (core/firebase/fcm.py 사용)
-            from core.firebase.fcm import send_push_notification
-
-            response = send_push_notification(
-                token=vehicle.fcm_token,
-                title=title,
-                body=body,
-                data={
-                    "detection_id": str(detection_id),
-                    "plate_number": detection.ocr_result or "",
-                    "speed": str(detection.detected_speed),
-                    "speed_limit": str(detection.speed_limit),
-                    "location": detection.location or "",
-                    "detected_at": detection.detected_at.isoformat(),
-                },
-            )
-
-        # 5. 성공 이력 저장 (notifications_db)
-        Notification.objects.using("notifications_db").create(
-            detection_id=detection_id,
-            fcm_token=vehicle.fcm_token,
-            title=title,
-            body=body,
-            status="sent",
-            sent_at=timezone.now(),
-        )
-
-        logger.info(f"Notification sent for detection {detection_id}: {response}")
-        return {"status": "sent", "fcm_response": response}
+        return {
+            "status": "sent",
+            "topic": bool(topic_response),
+            "vehicle": bool(vehicle and vehicle.fcm_token),
+        }
 
     except Detection.DoesNotExist:
-        logger.error(f"Detection {detection_id} not found")
+        logger.error(f"Detection {detection_id} not found or not completed")
         return {"status": "error", "reason": "Detection not found"}
 
     except Exception as exc:
-        # FCM 실패 시 이력 저장 후 재시도
         try:
+            from apps.notifications.models import Notification
+
             Notification.objects.using("notifications_db").create(
                 detection_id=detection_id,
                 status="failed",

--- a/tasks/notification_tasks.py
+++ b/tasks/notification_tasks.py
@@ -55,9 +55,15 @@ def send_notification(self, detection_id: int):
 
         # 3. 대시보드 토픽으로 항상 전송 (중복 방지)
         topic_response = None
-        already_sent_topic = Notification.objects.using("notifications_db").filter(
-            detection_id=detection_id, fcm_token="topic:dashboard_alerts", status="sent"
-        ).exists()
+        already_sent_topic = (
+            Notification.objects.using("notifications_db")
+            .filter(
+                detection_id=detection_id,
+                fcm_token="topic:dashboard_alerts",
+                status="sent",
+            )
+            .exists()
+        )
 
         if not already_sent_topic:
             try:
@@ -134,8 +140,7 @@ def send_notification(self, detection_id: int):
                 )
             except Exception as e:
                 logger.warning(
-                    f"Vehicle notification failed for detection "
-                    f"{detection_id}: {e}"
+                    f"Vehicle notification failed for detection " f"{detection_id}: {e}"
                 )
                 Notification.objects.using("notifications_db").create(
                     detection_id=detection_id,
@@ -167,7 +172,9 @@ def send_notification(self, detection_id: int):
                 error_message=str(exc),
             )
         except Exception as db_err:
-            logger.error(f"Failed to record notification failure for detection {detection_id}: {db_err}")
+            logger.error(
+                f"Failed to record notification failure for detection {detection_id}: {db_err}"
+            )
 
         logger.error(f"Notification failed for detection {detection_id}: {exc}")
         raise

--- a/tasks/notification_tasks.py
+++ b/tasks/notification_tasks.py
@@ -38,9 +38,9 @@ def send_notification(self, detection_id: int):
         )
 
         # 2. 알림 메시지 생성
-        title = f"⚠️ 과속 위반 감지: {detection.ocr_result}"
+        title = f"⚠️ 과속 위반 감지: {detection.ocr_result or '미확인'}"
         body = (
-            f"📍 위치: {detection.location}\n"
+            f"📍 위치: {detection.location or '알 수 없음'}\n"
             f"🚗 속도: {detection.detected_speed}km/h "
             f"(제한: {detection.speed_limit}km/h)"
         )
@@ -53,37 +53,48 @@ def send_notification(self, detection_id: int):
             "detected_at": detection.detected_at.isoformat(),
         }
 
-        # 3. 대시보드 토픽으로 항상 전송
+        # 3. 대시보드 토픽으로 항상 전송 (중복 방지)
         topic_response = None
-        try:
-            if FCM_MOCK:
-                topic_response = f"mock-topic-{detection_id}"
-            else:
-                from core.firebase.fcm import send_topic_notification
+        already_sent_topic = Notification.objects.using("notifications_db").filter(
+            detection_id=detection_id, fcm_token="topic:dashboard_alerts", status="sent"
+        ).exists()
 
-                topic_response = send_topic_notification(
-                    "dashboard_alerts", title, body, data
+        if not already_sent_topic:
+            try:
+                if FCM_MOCK:
+                    topic_response = f"mock-topic-{detection_id}"
+                else:
+                    from core.firebase.fcm import send_topic_notification
+
+                    topic_response = send_topic_notification(
+                        "dashboard_alerts", title, body, data
+                    )
+                logger.info(
+                    f"Dashboard topic notification sent for detection "
+                    f"{detection_id}: {topic_response}"
                 )
-            logger.info(
-                f"Dashboard topic notification sent for detection "
-                f"{detection_id}: {topic_response}"
-            )
-        except Exception as e:
-            logger.warning(
-                f"Dashboard topic notification failed for detection "
-                f"{detection_id}: {e}"
-            )
+            except Exception as e:
+                logger.warning(
+                    f"Dashboard topic notification failed for detection "
+                    f"{detection_id}: {e}"
+                )
 
-        # 4. 토픽 알림 이력 저장 (notifications_db)
-        Notification.objects.using("notifications_db").create(
-            detection_id=detection_id,
-            fcm_token="topic:dashboard_alerts",
-            title=title,
-            body=body,
-            status="sent" if topic_response else "failed",
-            sent_at=timezone.now() if topic_response else None,
-            error_message=None if topic_response else "Topic send failed",
-        )
+            # 4. 토픽 알림 이력 저장 (notifications_db)
+            Notification.objects.using("notifications_db").create(
+                detection_id=detection_id,
+                fcm_token="topic:dashboard_alerts",
+                title=title,
+                body=body,
+                status="sent" if topic_response else "failed",
+                sent_at=timezone.now() if topic_response else None,
+                error_message=None if topic_response else "Topic send failed",
+            )
+        else:
+            topic_response = "already_sent"
+            logger.info(
+                f"Dashboard topic notification already sent for detection "
+                f"{detection_id}, skipping"
+            )
 
         # 5. 매칭된 차량에 개별 푸시 (기존 동작)
         vehicle = None
@@ -142,8 +153,8 @@ def send_notification(self, detection_id: int):
         }
 
     except Detection.DoesNotExist:
-        logger.error(f"Detection {detection_id} not found or not completed")
-        return {"status": "error", "reason": "Detection not found"}
+        logger.warning(f"Detection {detection_id} not found or not completed, retrying")
+        raise self.retry(countdown=3, max_retries=3)
 
     except Exception as exc:
         try:
@@ -155,8 +166,8 @@ def send_notification(self, detection_id: int):
                 retry_count=self.request.retries,
                 error_message=str(exc),
             )
-        except Exception:
-            pass
+        except Exception as db_err:
+            logger.error(f"Failed to record notification failure for detection {detection_id}: {db_err}")
 
         logger.error(f"Notification failed for detection {detection_id}: {exc}")
         raise

--- a/tasks/ocr_tasks.py
+++ b/tasks/ocr_tasks.py
@@ -135,7 +135,9 @@ def process_ocr(self, detection_id: int, gcs_uri: str):
         try:
             send_notification.apply_async(args=[detection_id], queue="fcm_queue")
         except Exception as e:
-            logger.warning(f"Failed to enqueue notification for detection {detection_id}: {e}")
+            logger.warning(
+                f"Failed to enqueue notification for detection {detection_id}: {e}"
+            )
 
         logger.info(f"OCR completed for detection {detection_id}: {plate_number}")
         return {

--- a/tasks/ocr_tasks.py
+++ b/tasks/ocr_tasks.py
@@ -127,14 +127,12 @@ def process_ocr(self, detection_id: int, gcs_uri: str):
                         using="detections_db",
                         update_fields=["vehicle_id", "updated_at"],
                     )
-
-                    # 7. FCM 토큰이 있으면 알림 Task 발행
-                    if vehicle.fcm_token:
-                        send_notification.apply_async(
-                            args=[detection_id], queue="fcm_queue"
-                        )
             except Exception as e:
                 logger.warning(f"Vehicle lookup failed: {e}")
+
+        # 7. Always send notification for completed detections
+        #    (dashboard gets topic notification; matched vehicle gets individual push)
+        send_notification.apply_async(args=[detection_id], queue="fcm_queue")
 
         logger.info(f"OCR completed for detection {detection_id}: {plate_number}")
         return {

--- a/tasks/ocr_tasks.py
+++ b/tasks/ocr_tasks.py
@@ -132,7 +132,10 @@ def process_ocr(self, detection_id: int, gcs_uri: str):
 
         # 7. Always send notification for completed detections
         #    (dashboard gets topic notification; matched vehicle gets individual push)
-        send_notification.apply_async(args=[detection_id], queue="fcm_queue")
+        try:
+            send_notification.apply_async(args=[detection_id], queue="fcm_queue")
+        except Exception as e:
+            logger.warning(f"Failed to enqueue notification for detection {detection_id}: {e}")
 
         logger.info(f"OCR completed for detection {detection_id}: {plate_number}")
         return {


### PR DESCRIPTION
## Summary
- FCMClient에 토픽 구독/전송 메서드 추가 (`subscribe_to_topic`, `send_to_topic`)
- 대시보드 FCM 토큰 등록 시 `dashboard_alerts` 토픽에 자동 구독
- `send_notification`을 모든 완료된 감지에 대해 호출하도록 변경 (차량 매칭 여부 무관)
- 대시보드 토픽 브로드캐스트 + 차량 개별 푸시 이중 구조로 개편

## Background
기존에는 `plate_number="DASHBOARD"`로 FCM 토큰을 등록했지만, OCR 결과가 "DASHBOARD"와 매칭될 수 없어 대시보드에 알림이 전달되지 않는 구조적 문제가 있었습니다. FCM 토픽 기반으로 전환하여 모든 대시보드 사용자가 실시간 알림을 수신할 수 있도록 합니다.

## Changes
- `core/firebase/fcm.py`: `subscribe_to_topic()`, `send_to_topic()` 메서드 및 편의 함수 추가
- `apps/vehicles/views.py`: `register_fcm`에서 DASHBOARD 토큰 → 토픽 자동 구독
- `tasks/ocr_tasks.py`: `send_notification` 호출을 차량 매칭 조건 밖으로 이동
- `tasks/notification_tasks.py`: 토픽 브로드캐스트 + 차량 개별 푸시 이중 구조

## Test plan
- [ ] `FCM_MOCK=true` 환경에서 OCR 완료 후 `send_notification` 호출 확인
- [ ] 토픽 알림 이력에 `fcm_token="topic:dashboard_alerts"` 저장 확인
- [ ] 차량 매칭 없는 감지에서도 대시보드 토픽 알림 전송 확인
- [ ] 기존 차량 개별 푸시 동작 유지 확인