### PR TITLE
fix: include id in vehicle creation response

### DIFF
--- a/apps/vehicles/serializers.py
+++ b/apps/vehicles/serializers.py
@@ -21,7 +21,8 @@ class VehicleSerializer(serializers.ModelSerializer):
 class VehicleCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Vehicle
-        fields = ["plate_number", "owner_name", "owner_phone", "fcm_token"]
+        fields = ["id", "plate_number", "owner_name", "owner_phone", "fcm_token"]
+        read_only_fields = ["id"]
 
 
 class FCMTokenUpdateSerializer(serializers.Serializer):


### PR DESCRIPTION
## Summary
- `VehicleCreateSerializer`의 `fields`에 `id`가 누락되어 `POST /api/v1/vehicles/` 응답에 생성된 리소스의 ID가 포함되지 않던 버그 수정
- 이로 인해 k6 부하테스트에서 FCM 토큰 업데이트 PATCH 요청이 `/api/v1/vehicles/undefined/fcm-token/`으로 전송되어 0% 성공률 발생

## Changes
- `apps/vehicles/serializers.py`: `VehicleCreateSerializer.Meta.fields`에 `"id"` 추가, `read_only_fields = ["id"]` 설정

## Test plan
- [x] `POST /api/v1/vehicles/` 응답에 `id` 필드가 포함되는지 확인
- [x] `PATCH /api/v1/vehicles/{id}/fcm-token/` 정상 동작 확인
- [x] k6 부하테스트 admin_ops 시나리오에서 FCM 토큰 업데이트 성공 확인